### PR TITLE
✨ Add placeholder content to pass template lint rule

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,1 +1,4 @@
-<template></template>
+<template>
+  <div>Hellow World</div>
+</template>
+

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,1 +1,4 @@
-<template></template>
+<template>
+  <div>About Page</div>
+</template>
+


### PR DESCRIPTION
This PR adds minimal `<div>` placeholders inside the empty `<template>` blocks in HelloWorld.vue and AboutView.vue so ESLint's `vue/valid-template-root` rule passes and CI no longer fails on empty templates.

### 📋 Tasks
- [x] Add placeholder `<div>` in HelloWorld.vue
- [x] Add placeholder `<div>` in AboutView.vue
- [ ] Ensure `/lint` job passes in GitHub Actions


This pull request implements the placeholder content to unblock the `template` lint rule.  
Closes #15
